### PR TITLE
Add a new option to enable or disable the scaling of text elements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Snap rotation when `num` degrees away from snap angle (default: value of `rotate
 
 Enables/disables scaling (default: `true`).
 
+`scaleText: true|false`
+
+Enables/disables scaling of text elements (default: `true`).
+
 `scaleSnap`: num|false
 
 Scale with n pixel increments (default: `false`).

--- a/raphael.free_transform.js
+++ b/raphael.free_transform.js
@@ -64,6 +64,7 @@ Raphael.fn.freeTransform = function(subject, options, callback) {
 			rotateSnap: false,
 			rotateSnapDist: 0,
 			scale: true,
+			scaleText: true,
 			scaleSnap: false,
 			scaleRange: false,
 			showBBox: false,
@@ -575,8 +576,8 @@ Raphael.fn.freeTransform = function(subject, options, callback) {
 				},
 				rotate    = ft.attrs.rotate - ft.offset.rotate;
 				scale     = {
-					x: ft.attrs.scale.x / ft.offset.scale.x,
-					y: ft.attrs.scale.y / ft.offset.scale.y
+					x: (item.el.type != 'text' || ft.opts.scaleText) ? (ft.attrs.scale.x / ft.offset.scale.x) : 1.0,
+					y: (item.el.type != 'text' || ft.opts.scaleText) ? (ft.attrs.scale.y / ft.offset.scale.y) : 1.0
 				},
 				translate = {
 					x: ft.attrs.translate.x - ft.offset.translate.x,


### PR DESCRIPTION
Particularly useful if you are applying the transform to a set of elements, but do not want to scale text elements.
