### PR TITLE
Support hiding the X/Y axis handles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Limit the minimum and maximum size of the object in pixels (default: `false`)
 
 Sets the radius of the handles in pixels (default: `5`).
 
+`showXYHandles: true|false`
+
+Enables/disables the handles on the X/Y axes (default: `true`).
 
 Callback
 --------

--- a/raphael.free_transform.js
+++ b/raphael.free_transform.js
@@ -68,6 +68,7 @@ Raphael.fn.freeTransform = function(subject, options, callback) {
 			scaleRange: false,
 			showBBox: false,
 			showBBoxHandles: false,
+			showXYHandles: true,
 			size: 5
 			},
 		subject: subject
@@ -175,23 +176,25 @@ Raphael.fn.freeTransform = function(subject, options, callback) {
 		}
 
 		if ( ft.opts.rotate || ft.opts.scale ) {
-			ft.axes.map(function(axis) {
-				ft.handles[axis] = new Object;
+			if ( ft.opts.showXYHandles ) {
+				ft.axes.map(function(axis) {
+					ft.handles[axis] = new Object;
 
-				ft.handles[axis].line = paper
-					.path([ 'M', ft.attrs.center.x, ft.attrs.center.y ])
-					.attr({
-						stroke: ft.opts.attrs.stroke,
-						'stroke-dasharray': '- ',
-						opacity: .5
-						})
-					;
+					ft.handles[axis].line = paper
+						.path([ 'M', ft.attrs.center.x, ft.attrs.center.y ])
+						.attr({
+							stroke: ft.opts.attrs.stroke,
+							'stroke-dasharray': '- ',
+							opacity: .5
+							})
+						;
 
-				ft.handles[axis].disc = paper
-					.circle(ft.attrs.center.x, ft.attrs.center.y, ft.opts.size)
-					.attr(ft.opts.attrs)
-					;
-			});
+					ft.handles[axis].disc = paper
+						.circle(ft.attrs.center.x, ft.attrs.center.y, ft.opts.size)
+						.attr(ft.opts.attrs)
+						;
+				});
+			}
 
 			if ( ft.opts.showBBox && ft.opts.showBBoxHandles ) {
 				if ( ft.opts.scale ) {


### PR DESCRIPTION
Now that we can resize elements using bbox handles, it would be useful to have a way to hide the handles on the X/Y axis.
