### PR TITLE
Document the `showBBoxHandles` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Limit the minimum and maximum size of the object in pixels (default: `false`)
 
 Sets the radius of the handles in pixels (default: `5`).
 
+`showBBoxHandles: true|false`
+
+Enables/disables resize drag handles at the corners of the object's bounding box (default: `false`).
 
 Callback
 --------


### PR DESCRIPTION
Adds missing docs for #17.
