### PR TITLE
corrected the variable leak in bbox

### DIFF
--- a/raphael.free_transform.js
+++ b/raphael.free_transform.js
@@ -32,7 +32,7 @@ Raphael.fn.freeTransform = function(subject, options, callback) {
 	}
 
 	var
-		paper = this;
+		paper = this,
 		bbox  = subject.getBBox(true)
 		;
 


### PR DESCRIPTION
changed the semi-column into a comma that way bbox doesn't get added to the global scope
var
        paper = this;
        bbox  = subject.getBBox(true)
        ;
