### PR TITLE
Fix for transform data when Raphael is using VML

### DIFF
--- a/raphael.free_transform.js
+++ b/raphael.free_transform.js
@@ -737,7 +737,7 @@ Raphael.fn.freeTransform = function(subject, options, callback) {
 	// Get the current transform values for each item
 	ft.items.map(function(item, i) {
 		if ( item.el._ && item.el._.transform ) {
-			item.el._.transform.map(function(transform) {
+			Raphael.parseTransformString(item.el._.transform).map(function(transform) {
 				if ( transform[0] ) {
 					switch ( transform[0].toUpperCase() ) {
 						case 'T':


### PR DESCRIPTION
raphael.free_transform was assuming that the transform data for an element would be an array of transforms; sometimes in VML mode, it's a transform string. This fix runs the transform through Raphael.parseTransformString, which will always return an array of transforms.
