### PR TITLE
Apply transformations after invoking the callback

### DIFF
--- a/raphael.free_transform.js
+++ b/raphael.free_transform.js
@@ -420,9 +420,9 @@ Raphael.fn.freeTransform = function(subject, options, callback) {
 
 					ft.attrs.ratio = ft.attrs.scale.x / ft.attrs.scale.y;
 
-					ft.apply();
-
 					asyncCallback([ 'scale' ]);
+
+					ft.apply();
 				}, function() {
 					var
 						rotate = ( ( 360 - ft.attrs.rotate ) % 360 ) / 180 * Math.PI,
@@ -480,9 +480,9 @@ Raphael.fn.freeTransform = function(subject, options, callback) {
 
 				applyLimits(bbox);
 
-				ft.apply();
-
 				asyncCallback([ 'drag' ]);
+
+				ft.apply();
 			}, function() {
 				// Offset values
 				ft.o = cloneObj(ft.attrs);


### PR DESCRIPTION
I wanted to implement my own version of snapping to grid but it ended up being too jerky because on every move FT would change the translate coordinates, apply and then my callback would snap it to where I want it to be. If instead we invoke the callback before calling apply it becomes possible to implement smoother snapping to grid.

In general this makes sense to me and solves my problem but I wanted to see if it makes sense to you.
