### PR TITLE
Remove call to Element#undrag from hideHandles

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,12 @@ Functions
 Programmatically apply transformations (see the example above).
 
 
-#### `hideHandles()`
+#### `hideHandles( opts )`
 
-Removes handles but keeps values set by the plugin in memory.
+Removes handles but keeps values set by the plugin in memory. By
+default removes all drag events from the elements. If you'd like to
+keep then while the handles are hidden, pass ``{undrag: false}`` to
+hideHandles().
 
 
 #### `showHandles()`

--- a/raphael.free_transform.js
+++ b/raphael.free_transform.js
@@ -580,10 +580,21 @@ Raphael.fn.freeTransform = function(subject, options, callback) {
 	/**
 	 * Remove handles
 	 */
-	ft.hideHandles = function() {
-		ft.items.map(function(item) {
-			item.el.undrag();
-		});
+
+	/*
+
+	*/
+	ft.hideHandles = function(opts) {
+		var opts = opts || {}
+		if ( typeof opts.undrag === 'undefined' ) {
+			opts.undrag = true;
+		}
+
+		if ( opts.undrag ) {
+			ft.items.map(function(item) {
+				item.el.undrag();
+			});
+		}
 
 		if ( ft.handles.center ) {
 			ft.handles.center.disc.remove();


### PR DESCRIPTION
In my app I'd like to show handles on active elements. Clicking or draging an element should activate the element. Because `hideHandles` removes drag events, that isn't really possible. This patch removes the call to `Element#undrag`.

I realise that this may break someone else's application. An alternative to just removing this code would be to make it possible to disable that call by some kind of default parameter.

Cheers,
Miloš
