### PR TITLE
Fix boundary constraints when using percentage-based width/height

### DIFF
--- a/raphael.free_transform.js
+++ b/raphael.free_transform.js
@@ -72,7 +72,7 @@
 			opts: {
 				animate: false,
 				attrs: { fill: '#fff', stroke: '#000' },
-				boundary: { x: paper._left || 0, y: paper._top || 0, width: paper.width, height: paper.height },
+				boundary: { x: paper._left || 0, y: paper._top || 0, width: paper.canvas.clientWidth, height: paper.canvas.clientHeight },
 				distance: 1.3,
 				drag: true,
 				draw: false,


### PR DESCRIPTION
Use paper.canvas dimensions instead of paper width and height to setup correct boundaries when using percentage-based dimensions for paper. Fixes #83
