### PR TITLE
fixes viewBoxRatio undefined error introduced in d05e474

### DIFF
--- a/raphael.free_transform.js
+++ b/raphael.free_transform.js
@@ -115,15 +115,16 @@
 				if ( ft.handles[axis] ) {
 					var
 						cx = ft.attrs.center.x + ft.attrs.translate.x + radius[axis] * ft.opts.distance * Math.cos(rad[axis]),
-						cy = ft.attrs.center.y + ft.attrs.translate.y + radius[axis] * ft.opts.distance * Math.sin(rad[axis]);
+						cy = ft.attrs.center.y + ft.attrs.translate.y + radius[axis] * ft.opts.distance * Math.sin(rad[axis]),
+						viewBoxRatio = { x: 1, y: 1 };
 						
 					// viewBox might be scaled
 					if ( paper._viewBox ) {
-						var viewBoxRatio = {
+						viewBoxRatio = {
 							x: paper._viewBox[2] / getPaperSize().x,
 							y: paper._viewBox[3] / getPaperSize().y
 						};
-					};
+					}
 
 					// Keep handle within boundaries
 					if ( ft.opts.boundary ) {
@@ -323,8 +324,8 @@
 
 					// Keep handle within boundaries
 					if ( ft.opts.boundary ) {
-						cx = Math.max(Math.min(cx, ft.opts.boundary.x + ( ft.opts.boundary.width  || getPaperSize().x * ft.o.viewBoxRatio.x )), ft.opts.boundary.x);
-						cy = Math.max(Math.min(cy, ft.opts.boundary.y + ( ft.opts.boundary.height || getPaperSize().y * ft.o.viewBoxRatio.y )), ft.opts.boundary.y);
+						cx = Math.max(Math.min(cx, ft.opts.boundary.x + ( ft.opts.boundary.width  || getPaperSize().x * (ft.o.viewBoxRatio && ft.o.viewBoxRatio.x || 1))), ft.opts.boundary.x);
+						cy = Math.max(Math.min(cy, ft.opts.boundary.y + ( ft.opts.boundary.height || getPaperSize().y * (ft.o.viewBoxRatio && ft.o.viewBoxRatio.y || 1))), ft.opts.boundary.y);
 					}
 
 					var radius = Math.sqrt(Math.pow(cx - ft.o.center.x - ft.o.translate.x, 2) + Math.pow(cy - ft.o.center.y - ft.o.translate.y, 2));
@@ -970,8 +971,8 @@
 			if ( ft.opts.boundary ) {
 				var b = ft.opts.boundary;
 
-				b.width  = b.width  || getPaperSize().x * ft.o.viewBoxRatio.x;
-				b.height = b.height || getPaperSize().y * ft.o.viewBoxRatio.y;
+				b.width  = b.width  || getPaperSize().x * (ft.o.viewBoxRatio && ft.o.viewBoxRatio.x || 1);
+				b.height = b.height || getPaperSize().y * (ft.o.viewBoxRatio && ft.o.viewBoxRatio.y || 1);
 
 				if ( ft.attrs.center.x + ft.attrs.translate.x < b.x            ) { ft.attrs.translate.x += b.x -            ( ft.attrs.center.x + ft.attrs.translate.x ); }
 				if ( ft.attrs.center.y + ft.attrs.translate.y < b.y            ) { ft.attrs.translate.y += b.y -            ( ft.attrs.center.y + ft.attrs.translate.y ); }


### PR DESCRIPTION
The last commit to master introduces an undefined error bug when viewBoxRatio is never used.
Example here: http://jsfiddle.net/A2J3N/
This fix either creates a default object or checks if the object exists.
