### PR TITLE
add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "main": "raphael.free_transform.js",
   "repository": "git@github.com:AliasIO/Raphael.FreeTransform.git",
   "author": "Elbert Alias <elbert@alias.io>",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "raphael": "^2.2.7"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "Raphael.FreeTransform",
+  "version": "1.0.0",
+  "main": "raphael.free_transform.js",
+  "repository": "git@github.com:AliasIO/Raphael.FreeTransform.git",
+  "author": "Elbert Alias <elbert@alias.io>",
+  "license": "MIT"
+}


### PR DESCRIPTION
This lets you install the package with the github URL using npm or yarn. Even if a package is not in the registry, both package managers require that a package.json file exist.

This does not add it to the npm registry nor does it obligate you to do so, but if you want to and you're bored on a rainy day you'd be able to just `npm publish`.

I took your contact info from your github profile. I can remove it if you want.